### PR TITLE
Fixed an issue where importing SwiftPM with Xcode failed to compile

### DIFF
--- a/ClassDump/ClassDump.h
+++ b/ClassDump/ClassDump.h
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Leptos. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 
 #import "Models/Reflections/CDClassModel.h"
 #import "Models/Reflections/CDProtocolModel.h"
@@ -35,4 +35,4 @@
 #import <ClassDump/CDVariableModel.h>
 #import <ClassDump/ClassDump.h>
 
-#endif /* SWIFT_PACKAGE */
+#endif /* !__has_include(<ClassDump/ClassDump.h>) */

--- a/ClassDump/Models/CDVariableModel.h
+++ b/ClassDump/Models/CDVariableModel.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "ParseTypes/CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/ParseTypes/CDArrayType.h
+++ b/ClassDump/Models/ParseTypes/CDArrayType.h
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Leptos. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/ParseTypes/CDBitFieldType.h
+++ b/ClassDump/Models/ParseTypes/CDBitFieldType.h
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Leptos. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/ParseTypes/CDBlockType.h
+++ b/ClassDump/Models/ParseTypes/CDBlockType.h
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Leptos. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/ParseTypes/CDObjectType.h
+++ b/ClassDump/Models/ParseTypes/CDObjectType.h
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Leptos. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/ParseTypes/CDParseType.h
+++ b/ClassDump/Models/ParseTypes/CDParseType.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "../CDSemanticString.h"
 #else
 #import <ClassDump/CDSemanticString.h>

--- a/ClassDump/Models/ParseTypes/CDPointerType.h
+++ b/ClassDump/Models/ParseTypes/CDPointerType.h
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Leptos. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/ParseTypes/CDPrimitiveType.h
+++ b/ClassDump/Models/ParseTypes/CDPrimitiveType.h
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Leptos. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/ParseTypes/CDRecordType.h
+++ b/ClassDump/Models/ParseTypes/CDRecordType.h
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Leptos. All rights reserved.
 //
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDParseType.h"
 #import "../CDVariableModel.h"
 #else

--- a/ClassDump/Models/Reflections/CDClassModel.h
+++ b/ClassDump/Models/Reflections/CDClassModel.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDIvarModel.h"
 #import "CDPropertyModel.h"
 #import "CDMethodModel.h"

--- a/ClassDump/Models/Reflections/CDIvarModel.h
+++ b/ClassDump/Models/Reflections/CDIvarModel.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "../ParseTypes/CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/Reflections/CDMethodModel.h
+++ b/ClassDump/Models/Reflections/CDMethodModel.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "../ParseTypes/CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>

--- a/ClassDump/Models/Reflections/CDPropertyModel.h
+++ b/ClassDump/Models/Reflections/CDPropertyModel.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "../ParseTypes/CDParseType.h"
 #import "CDPropertyAttribute.h"
 #else

--- a/ClassDump/Models/Reflections/CDProtocolModel.h
+++ b/ClassDump/Models/Reflections/CDProtocolModel.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "CDPropertyModel.h"
 #import "CDMethodModel.h"
 #else

--- a/ClassDump/Services/CDTypeParser.h
+++ b/ClassDump/Services/CDTypeParser.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#if SWIFT_PACKAGE
+#if !__has_include(<ClassDump/ClassDump.h>)
 #import "../Models/ParseTypes/CDParseType.h"
 #else
 #import <ClassDump/CDParseType.h>


### PR DESCRIPTION
As the title says, using SwiftPM packages in Xcode does not seem to define SWIFT_PACKAGE, leading to compilation failure. I have consulted relevant information, and it seems that this macro definition only takes effect in internal files and is not exported in public files.